### PR TITLE
tokens, docs, and packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,53 +1,43 @@
 # github-init
 
-Command Line tool to create repo on github.
+> Command Line tool to create repository on GitHub
 
-![github-init](github.gif)
-
-### Prerequisites
-
-Need Node.js to be installed on computer.
-
-Install [dns](https://github.com/hbouvier/dns) npm package on your computer.
+## Install
 
 ```
-sudo npm install -g dns
+$ [sudo] npm install -g github
 ```
 
-### Installing
+## Preview
 
-Clone the repo
+<p align="center">
+<img src="https://raw.githubusercontent.com/rabingaire/github-init/master/github.gif">
+</p>
 
-Open terminal
-
-```
-cd github-int
-```
-
-Now install all the required packages by
+## Usage 
 
 ```
-yarn install 
+ $ github
 ```
 
-or
+## Setup
 
-```
-npm install
-```
+This tool requires auth tokens to create repositories on Github. You'll need to follow the given steps in order to use this tool.
 
-Now you will need to get the Personal access token from Github account to get that you need to go to this [page](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/).
+- Generate [Personal Access Tokens](https://github.com/settings/tokens/new)
 
-After generating the access token copy and paste it to the token.js file.
+- Run `$ github` and hit `ctrl + c`
 
-Install it globally to your machine by running 
+- Now, go to your `home directory` which is basically `/home/username` and hit `ctrl + h` to find the hidden folders
 
-```
-sudo npm -g install
-``` 
+- Search for `.repogit` folder
 
-type `github` to run the tool.
+- Open the `token.json` file insdie the `.repogit` folder
+
+- Paste your `personal access token` and save the file.
+
+- Run `$ github` again to successfully create repositories
 
 ## License
 
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+MIT &copy; [Rabin Gaire](http://rabingaire.com.np/)

--- a/index.js
+++ b/index.js
@@ -1,87 +1,112 @@
 #!/usr/bin/env node
 
+'use strict';
+
 const axios = require('axios');
 const chalk = require('chalk');
 const dns = require('dns');
 const execa = require('execa');
+const fs = require('fs');
+const fse = require('fs-extra');
 const inquirer = require('inquirer');
-const lang = require('./lang/default')
+const jsonFile = require('jsonfile');
 const logUpdate = require('log-update');
+const os = require('os');
 const ora = require('ora');
-const TOKEN = require('./token');
+const updateNotifier = require('update-notifier');
+const lang = require('./lang/default');
+const pkg = require('./package.json');
+
+updateNotifier({pkg}).notify();
 
 const spinner = ora();
 
+const token = `${os.homedir()}/.repogit/token.json`;
+const obj = {
+	token: 'Put your access token here!'
+};
+
+if (!fs.existsSync(token)) {
+	fse.ensureFile(token, err => {
+		logUpdate(err);
+		jsonFile.writeFile(token, obj, err => {
+			logUpdate(err);
+		});
+	});
+}
+
 dns.lookup('github.com', err => {
-    if (err) {
-        logUpdate(`\n${chalk.red.bold(' ✘')}${chalk.dim('  Can\'t create the repository. Check your internet connection!\n')}`);
-        process.exit(1);
-    } else {
-        const headers = {
-            'Authorization': `token ${TOKEN}`
-        };
+	if (err) {
+		logUpdate(`\n${chalk.red.bold(' ✘')}${chalk.dim('  Can\'t create the repository. Check your internet connection!\n')}`);
+		process.exit(1);
+	} else {
+		jsonFile.readFile(token, (err, keys) => {
+			logUpdate(err);
+			const key = keys.token;
 
-        logUpdate();
+			const headers = {
+				Authorization: `token ${key}`
+			};
 
-        const parameter = [{
-            type: 'input',
-            name: 'name',
-            message: lang.repoName
-        }, {
-            type: 'input',
-            name: 'description',
-            message: lang.repoDesciption
-        }, {
-            type: 'list',
-            name: 'auto_init',
-            message: lang.repoReadme,
-            choices: [
-                "Yes",
-                "No",
-            ]
-        }, {
-            type: 'list',
-            name: 'private',
-            message: lang.repoMakePrivate,
-            choices: [
-                "Yes",
-                "No",
-            ]
-        }, ]
+			logUpdate();
 
-        inquirer.prompt(parameter).then(answers => {
-            let data = {
-                name: answers.name,
-                description: answers.description,
-                gitignore_template: "nanoc"
-            };
+			const parameter = [{
+				type: 'input',
+				name: 'name',
+				message: lang.repoName
+			}, {
+				type: 'input',
+				name: 'description',
+				message: lang.repoDesciption
+			}, {
+				type: 'list',
+				name: 'auto_init',
+				message: lang.repoReadme,
+				choices: [
+					'Yes',
+					'No'
+				]
+			}, {
+				type: 'list',
+				name: 'private',
+				message: lang.repoMakePrivate,
+				choices: [
+					'Yes',
+					'No'
+				]
+			}];
 
-            data.auto_init = answers.auto_init === 'Yes';
-            data.private = answers.private === 'Yes';
+			inquirer.prompt(parameter).then(answers => {
+				const data = {
+					name: answers.name,
+					description: answers.description,
+					gitignore_template: "nanoc"
+				};
 
-            axios({
-                    method: 'post',
-                    url: '/user/repos',
-                    baseURL: 'https://api.github.com',
-                    headers: headers,
-                    data: data
-                }).then(response => {
-                    const link = response.data.ssh_url;
-                    spinner.text = ' Cloning';
-                    logUpdate();
-                    spinner.start();
-                    execa('git', ['clone', `${link}`]).then(res => {
-                        logUpdate(`\n ${chalk.blue.bold('✓')} Done 
+				data.auto_init = answers.auto_init === 'Yes';
+				data.private = answers.private === 'Yes';
 
- ${chalk.blue.bold('✓')} Cloned in ~ ${process.cwd()}/${answers.name}\n`);
-                        spinner.stop();
-                    })
-
-                })
-                .catch(error => {
-                    const errorMessage = error.message;
-                    console.log(`\n${chalk.red('✘')} Could not create the repository ${chalk.dim('[Unprocessable Entity]')}\n`);
-                });
-        });
-    }
-})
+				axios({
+					method: 'post',
+					url: '/user/repos',
+					baseURL: 'https://api.github.com',
+					headers: headers,
+					data: data
+				}).then(response => {
+					const link = response.data.ssh_url;
+					spinner.text = ' Cloning';
+					logUpdate();
+					spinner.start();
+					execa('git', ['clone', `${link}`]).then(() => {
+						logUpdate(`\n ${chalk.blue.bold('✓')} Done \n\n ${chalk.blue.bold('✓')} Cloned in ~ ${process.cwd()}/${answers.name}\n`);
+						spinner.stop();
+					});
+				}).catch(err => {
+					if (err) {
+						console.log(`\n${chalk.red('✘')} Could not create the repository ${chalk.dim('[Unprocessable Entity]')}\n`);
+					}
+				});
+			});
+		});
+	}
+});

--- a/package.json
+++ b/package.json
@@ -1,23 +1,49 @@
 {
   "name": "github-init",
   "version": "1.0.0",
-  "description": "Command line tool to create repo on github.",
+  "description": "Command line tool to create GitHub repositories.",
   "main": "index.js",
   "scripts": {
-    "start": "node index.js"
+    "test": "ava"
+  },
+  "engines": {
+    "node": ">=4"
   },
   "author": "Rabin Gaire",
   "license": "MIT",
   "bin": {
-    "github": "./index.js"
+    "github": "index.js"
   },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/rabingaire/github-init.git"
+  },
+  "keywords": [
+    "github",
+    "repository",
+    "create",
+    "cli-app",
+    "commandline"
+    "git"
+  ],
   "dependencies": {
     "axios": "^0.16.2",
     "chalk": "^2.1.0",
-    "commander": "^2.11.0",
     "execa": "^0.8.0",
+    "fs-extra": "^4.0.2",
     "inquirer": "^3.3.0",
+    "jsonfile": "^4.0.0",
     "log-update": "^2.2.0",
-    "ora": "^1.3.0"
-  }
+    "ora": "^1.3.0",
+    "update-notifier": "^2.3.0"
+  },
+  "devDependencies": {
+    "ava": "0.16.0"
+  },
+  "author": "Rabin Gaire",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/rabingaire/github-init/issues"
+  },
+  "homepage": "https://github.com/rabingaire/github-init#readme"
 }

--- a/token.js
+++ b/token.js
@@ -1,3 +1,0 @@
-const TOKEN = "";  //Paste your token here 
-
-module.exports = TOKEN;


### PR DESCRIPTION
This pull request adds the feature of setting up personal access tokens in a better way!

- Run the script once and cancel the process.

- Script creates a hidden folder under the home directory 
__Example :__ `token.json` file gets created under `.repogit` folder in home directory i.e., `$os.homedir()`

- We need to save the access token in `token.json` file.

- Run the script again and it successfully reads the `personal access token` of the user from the hidden file.

- Creates a repository!

I've updated the `readme` and `package.json` file. They all are set. You can __publish__ the tool now!
